### PR TITLE
check for pluralGenerator in message values

### DIFF
--- a/lib/compile-extracts.js
+++ b/lib/compile-extracts.js
@@ -4,6 +4,20 @@ function alwaysArray( itemOrArray ) {
 	return Array.isArray( itemOrArray ) ? itemOrArray : itemOrArray ? [ itemOrArray ] : [];
 }
 
+// allow plurals to be included without explicitly declaring them
+function pluralGenerator( _globalize ) {
+	return [ _globalize.pluralGenerator() ];
+}
+
+var PLURAL_MESSAGE = /{.*,\s*plural\s*,.*}/;
+
+function probablyContainsPlurals( msgObject, defaultLocale ) {
+	var defaultStrings = msgObject[ defaultLocale ];
+	return Object.keys( defaultStrings ).find( function( key ) {
+		return PLURAL_MESSAGE.test( defaultStrings[ key ] );
+	} );
+}
+
 function compileExtracts( attributes ) {
 	var cldr, cldrObject, defaultLocale, extracts, formattersAndParsers, messages, messagesObject;
 	var Globalize = require( "globalize" );
@@ -42,6 +56,13 @@ function compileExtracts( attributes ) {
 			return messagesObject;
 		};
 	}
+
+	extracts = alwaysArray( extracts );
+
+	if ( probablyContainsPlurals( messagesObject, defaultLocale ) ) {
+		extracts.push( pluralGenerator );
+	}
+
 
 	// TODO
 	//assert( defaultLocale )

--- a/test/fixtures/messages.js
+++ b/test/fixtures/messages.js
@@ -1,0 +1,20 @@
+var like;
+var Globalize = require( "globalize" );
+
+Globalize.load(
+	require( "cldr-data/main/en/ca-gregorian" ),
+	require( "cldr-data/main/en/numbers" ),
+	require( "cldr-data/supplemental/plurals" ),
+	require( "cldr-data/supplemental/likelySubtags" )
+);
+Globalize.loadMessages( require( "./messages/en" ) );
+
+// Set "en" as our default locale.
+Globalize.locale( "en" );
+
+// Use Globalize to format a message with plural inflection.
+like = Globalize.messageFormatter( "like" );
+console.log( like( 0 ) );
+console.log( like( 1 ) );
+console.log( like( 2 ) );
+console.log( like( 3 ) );

--- a/test/index.js
+++ b/test/index.js
@@ -5,19 +5,75 @@ var globalizeCompiler = require("../index");
 
 var fixtures = {
   //babel: esprima.parse(babel.transform(fs.readFileSync(__dirname + "/fixtures/es6.js")).code),
-  basic: esprima.parse(fs.readFileSync(__dirname + "/fixtures/basic.js"))
+  basic: esprima.parse(fs.readFileSync(__dirname + "/fixtures/basic.js")),
+  messages: esprima.parse(fs.readFileSync(__dirname + "/fixtures/messages.js"))
 };
+
+var enMessages = {
+  en: {
+    like: "{0, plural, one {like} other {likes} }"
+  }
+};
+
+var DEFINE_BLOCK = /define\( (\[[^\]]+\]), /;
+var VARIABLE_DECLARATION = /^var (\w+) = .*;$/;
+
+function getAMDDependencies(func) {
+  var fnString = func.toString();
+  var dependencies = fnString.match(DEFINE_BLOCK)[1];
+
+  return JSON.parse(dependencies);
+}
+
+function getVariableDeclarations(func) {
+  var fnString = func.toString();
+
+  return fnString.split("\n").filter(function(s) {
+    return VARIABLE_DECLARATION.test(s);
+  });
+}
 
 describe("Extract Formatters & Parsers", function() {
   it("should extract formatters and parsers from basic code", function() {
     var extract = globalizeCompiler.extract(fixtures.basic);
     expect(extract).to.be.a("function");
 
-    // FIXME
+    /* FIXME
     console.log(globalizeCompiler.compileExtracts({
       defaultLocale: "en",
-      extracts: extract
+      extracts: extract,
+      messages: enMessages
     }));
+    */
   });
 
+  it("should provide the right dependencies for message pluralization", function() {
+    var compiled, dependencies, extracts, messageFormatterVar, pluralGeneratorVar,
+      variableDeclarations;
+
+    extracts = globalizeCompiler.extract(fixtures.messages);
+
+    compiled = globalizeCompiler.compileExtracts({
+      defaultLocale: "en",
+      extracts: extracts,
+      messages: enMessages
+    });
+
+    dependencies = getAMDDependencies(compiled);
+
+    expect(dependencies).to.include("globalize-runtime/message");
+    expect(dependencies).to.include("globalize-runtime/plural");
+
+    variableDeclarations = getVariableDeclarations(compiled);
+
+    messageFormatterVar = variableDeclarations.find(function (_var) {
+      return _var.match(VARIABLE_DECLARATION)[1] === "messageFormatterFn";
+    });
+    expect(messageFormatterVar).to.exist;
+
+    pluralGeneratorVar = variableDeclarations.find(function (_var) {
+      return _var.match(VARIABLE_DECLARATION)[1] === "pluralGeneratorFn";
+    });
+    expect(pluralGeneratorVar).to.exist;
+  });
 });


### PR DESCRIPTION
Problem: if you don't make an explicit call to `Globalize.plural`, the generated files from globalize-compiler do not set up the plural generator correctly. This causes an obscure error in messageformat.js:

```
Uncaught TypeError: lcfunc is not a function
```

I've patched `compile-extracts` to infer from the message data whether the plural generator and CLDR content is required, and if so, pass the generator function along to `compile`.
