### PR TITLE
Make template customizable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ var globalizeCompiler = require( "globalize-compiler" );
 
 &nbsp;&nbsp;&nbsp; **template** optional. A function that replaces the default template. The function will receive a single *Object* parameter with two properties:
 
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; **compiled**: string, the source of the compiled formatters and parsers.
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; **code**: string, the source of the compiled formatters and parsers.
 
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; **dependencies**: array, a list of globalize runtime modules that the compiled code depends on, e.g. `globalize-runtime/number`.
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ var globalizeCompiler = require( "globalize-compiler" );
 //     extract: [Function: extractor] }
 ```
 
-#### `.compile( formattersAndParsers )`
+#### `.compile( formattersAndParsers, options )`
 
 **formattersAndParsers** is an *Array* or an *Object* containing formatters and/or parsers, e.g.:
 
@@ -73,6 +73,14 @@ var globalizeCompiler = require( "globalize-compiler" );
     ...
 }
 ```
+
+**options** is an *Object* with the following properties:
+
+&nbsp;&nbsp;&nbsp; **template** optional. A function that replaces the default template. The function will receive a single *Object* parameter with two properties:
+
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; **compiled**: string, the source of the compiled formatters and parsers.
+
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; **dependencies**: array, a list of globalize runtime modules that the compiled code depends on, e.g. `globalize-runtime/number`.
 
 **Returns** a *String* with the generated JavaScript bundle (UMD wrapped) including the compiled formatters and parsers.
 
@@ -132,6 +140,8 @@ globalize.formatNumber( ... );
 &nbsp;&nbsp;&nbsp; **cldr** optional. It's an *Object* with CLDR data (in the JSON format) or a *Function* taking one argument: locale, a *String*; returning an *Object* with the CLDR data for the passed locale. Defaults to the entire supplemental data plus the entire main data for the defaultLocale.
 
 &nbsp;&nbsp;&nbsp; **messages** optional. It's an *Object* with messages data (in the JSON format) or a *Function* taking one argument: locale, a *String*; returning an *Object* with the messages data for the passed locale. Defaults to `{}`.
+
+&nbsp;&nbsp;&nbsp; **template** optional. A function that replaces the default template. See [`.compile()`][] for more details.
 
 **Returns** a *String* with the generated JavaScript bundle as returned by the [`.compile()`][] function.
 

--- a/lib/compile-extracts.js
+++ b/lib/compile-extracts.js
@@ -9,6 +9,10 @@ function compileExtracts( attributes ) {
 	var Globalize = require( "globalize" );
 
 	attributes = attributes || {};
+	var compilerOptions = {};
+	if (attributes.template) {
+		compilerOptions.template = attributes.template;
+	}
 
 	// Required attributes.
 	defaultLocale = attributes.defaultLocale;
@@ -56,7 +60,7 @@ function compileExtracts( attributes ) {
 		return sum;
 	}, [] );
 
-	return compile( formattersAndParsers );
+	return compile( formattersAndParsers, compilerOptions );
 }
 
 module.exports = compileExtracts;

--- a/lib/compile.js
+++ b/lib/compile.js
@@ -134,6 +134,27 @@ function deduceDependenciesVars( formatterOrParser ) {
 }
 
 /**
+ * Default template function
+ * properties:
+ *  - compiled
+ *  - dependencies
+ */
+function defaultTemplate( properties ) {
+	var params = {};
+
+	params.compiled = properties.compiled;
+	params.dependenciesAmd = JSON.stringify( properties.dependencies );
+	params.dependenciesCjs = properties.dependencies.map(function( dependency ) {
+		return "require(\"globalize/dist/" + dependency + "\")";
+	}).join( ", " );
+
+	return template.replace( /{{[a-zA-Z]+}}/g, function( name ) {
+		name = name.slice( 2, -2 );
+		return params[ name ];
+	});
+}
+
+/**
  * compiler( formatterOrParser, ... ), or
  * compiler({ formatterOrParserName: formatterOrParser, ... })
  *
@@ -143,7 +164,9 @@ function deduceDependenciesVars( formatterOrParser ) {
  */
 function compiler() {
 	var dependencies,
+		dependenciesVars,
 		args = slice.call( arguments, 0 ),
+		templateFn = defaultTemplate,
 		formattersAndParsers = [],
 		formattersAndParsersKeys = [],
 		properties = {};
@@ -175,6 +198,11 @@ function compiler() {
 		throw new Error( "No formatters or parsers has been provided" );
 	}
 
+	if ( args.length && typeof args[args.length - 1] === "object" &&
+			typeof args[args.length - 1].template === "function" ) {
+		templateFn = args[args.length - 1].template;
+	}
+
 	// Generate the compiled functions.
 	properties.compiled = formattersAndParsers.sort(function( a, b ) {
 		a = functionName( a );
@@ -186,21 +214,21 @@ function compiler() {
 	dependencies = Object.keys( formattersAndParsers.map( functionName ).reduce(function( sum, i ) {
 		return extend( sum, DEPENDENCIES[ i ] );
 	}, {}));
-	properties.dependenciesAmd = JSON.stringify( dependencies.map(function( dependency ) {
+
+	properties.dependencies = dependencies.map(function( dependency ) {
 		return "globalize-runtime/" + dependency;
-	}));
-	properties.dependenciesCjs = dependencies.map(function( dependency ) {
-		return "require(\"globalize/dist/globalize-runtime/" + dependency + "\")";
-	}).join( ", " );
-	properties.dependenciesVars = formattersAndParsers
+	});
+	dependenciesVars = formattersAndParsers
 		.map( deduceDependenciesVars )
 		.reduce(function( sum, i ) {
 			return extend( sum, i );
 		}, {});
-	properties.dependenciesVars = Object.keys( properties.dependenciesVars )
+	dependenciesVars = Object.keys( dependenciesVars )
 		.map(function( dependency ) {
 			return "var " + dependency + " = Globalize._" + dependency + ";";
 		}).join( "\n" );
+
+	properties.compiled = dependenciesVars + "\n" + properties.compiled;
 
 	/*
 	// Generate exports.
@@ -212,10 +240,7 @@ function compiler() {
 	properties.exports = "return " + stringifyIncludingFunctionsAndUndefined( properties.exports );
 	*/
 
-	return template.replace( /{{[a-zA-Z]+}}/g, function( name ) {
-		name = name.slice( 2, -2 );
-		return properties[ name ];
-	});
+	return templateFn(properties);
 }
 
 module.exports = compiler;

--- a/lib/compile.js
+++ b/lib/compile.js
@@ -142,7 +142,7 @@ function deduceDependenciesVars( formatterOrParser ) {
 function defaultTemplate( properties ) {
 	var params = {};
 
-	params.compiled = properties.compiled;
+	params.compiled = properties.code;
 	params.dependenciesAmd = JSON.stringify( properties.dependencies );
 	params.dependenciesCjs = properties.dependencies.map(function( dependency ) {
 		return "require(\"globalize/dist/" + dependency + "\")";
@@ -155,21 +155,21 @@ function defaultTemplate( properties ) {
 }
 
 /**
- * compiler( formatterOrParser, ... ), or
- * compiler({ formatterOrParserName: formatterOrParser, ... })
- *
- * @formatterOrParser
- *
  * Returns a string with the compiled formatters and parsers.
+ *
+ * @param {formattersAndParsers} object or array
+ * @param {options} object
  */
-function compiler() {
+function compiler( formattersAndParsers, options ) {
 	var dependencies,
+		code,
 		dependenciesVars,
-		args = slice.call( arguments, 0 ),
-		templateFn = defaultTemplate,
-		formattersAndParsers = [],
-		formattersAndParsersKeys = [],
-		properties = {};
+		templateFn,
+		extractedFormattersAndParsers = [],
+		formattersAndParsersKeys = [];
+
+	options = options || {};
+	templateFn = options.template || defaultTemplate;
 
 	// Extract Formatters and Parsers from arguments (and its nested formatters and parsers).
 	function extractFormattersAndParsers( object ) {
@@ -177,7 +177,7 @@ function compiler() {
 
 			// If a node is a formatter or a parser function, push it to our Array.
 			if ( typeof value === "function" && "runtimeArgs" in value ) {
-				formattersAndParsers.push( value );
+				extractedFormattersAndParsers.push( value );
 
 				// ... and do the same for its runtimeArgs (extract nested formatters or parsers).
 				extractFormattersAndParsers( value.runtimeArgs );
@@ -191,34 +191,29 @@ function compiler() {
 		formattersAndParsersKeys.push( formatterOrParser.runtimeKey );
 		return filter;
 	}
-	extractFormattersAndParsers( args );
-	formattersAndParsers = formattersAndParsers.filter( uniqueFormattersAndParsers );
+	extractFormattersAndParsers( formattersAndParsers );
+	extractedFormattersAndParsers = extractedFormattersAndParsers.filter( uniqueFormattersAndParsers );
 
-	if ( !formattersAndParsers.length ) {
+	if ( !extractedFormattersAndParsers.length ) {
 		throw new Error( "No formatters or parsers has been provided" );
 	}
 
-	if ( args.length && typeof args[args.length - 1] === "object" &&
-			typeof args[args.length - 1].template === "function" ) {
-		templateFn = args[args.length - 1].template;
-	}
-
 	// Generate the compiled functions.
-	properties.compiled = formattersAndParsers.sort(function( a, b ) {
+	code = extractedFormattersAndParsers.sort(function( a, b ) {
 		a = functionName( a );
 		b = functionName( b );
 		return COMPILED_ORDER.indexOf( a ) - COMPILED_ORDER.indexOf( b );
 	}).map( compile ).join( "\n" );
 
 	// Generate dependency assignments and requirements.
-	dependencies = Object.keys( formattersAndParsers.map( functionName ).reduce(function( sum, i ) {
+	dependencies = Object.keys( extractedFormattersAndParsers.map( functionName ).reduce(function( sum, i ) {
 		return extend( sum, DEPENDENCIES[ i ] );
 	}, {}));
 
-	properties.dependencies = dependencies.map(function( dependency ) {
+	dependencies = dependencies.map(function( dependency ) {
 		return "globalize-runtime/" + dependency;
 	});
-	dependenciesVars = formattersAndParsers
+	dependenciesVars = extractedFormattersAndParsers
 		.map( deduceDependenciesVars )
 		.reduce(function( sum, i ) {
 			return extend( sum, i );
@@ -228,7 +223,7 @@ function compiler() {
 			return "var " + dependency + " = Globalize._" + dependency + ";";
 		}).join( "\n" );
 
-	properties.compiled = dependenciesVars + "\n" + properties.compiled;
+	code = dependenciesVars + "\n\n" + code;
 
 	/*
 	// Generate exports.
@@ -240,7 +235,10 @@ function compiler() {
 	properties.exports = "return " + stringifyIncludingFunctionsAndUndefined( properties.exports );
 	*/
 
-	return templateFn(properties);
+	return templateFn({
+		code: code,
+		dependencies: dependencies
+	});
 }
 
 module.exports = compiler;

--- a/lib/compile.template
+++ b/lib/compile.template
@@ -16,8 +16,6 @@
 	}
 }( this, function( Globalize ) {
 
-{{dependenciesVars}}
-
 {{compiled}}
 
 return Globalize;


### PR DESCRIPTION
Fixes #6

I only tested compile with the new option. I also tested two examples in the globalize repo (app-npm-webpack and globalize-compiler) without the new option.

Btw, npm run test didn't work properly for me. jshint succeeded, even though there were errors, and when I ran jshint manually, it did report them.
