### PR TITLE
Change compile order: put messageFormatters last.

### DIFF
--- a/lib/compile.js
+++ b/lib/compile.js
@@ -9,15 +9,15 @@ COMPILED_ORDER = [
 	"numberParser",
 	"pluralGenerator",
 
-	// Depends on plural.
-	"messageFormatter",
-
 	// Depends on number and/or plural.
 	"currencyFormatter",
 	"dateFormatter",
 	"dateParser",
 	"relativeTimeFormatter",
-	"unitFormatter"
+	"unitFormatter",
+
+	// Depends on everything.
+	"messageFormatter"
 ];
 
 DEPENDENCIES = {


### PR DESCRIPTION
See https://github.com/jquery/globalize/issues/563

Fixes #16
