### PR TITLE
Fix function name typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ var globalizeCompiler = require( "globalize-compiler" );
 **Example**
 
 ```javascript
-fs.writeSyncFile( "my-formatters-and-parsers.js", globalizeCompiler.compile([
+fs.writeFileSync( "my-formatters-and-parsers.js", globalizeCompiler.compile([
     formatter1,
     formatter2,
     ...,


### PR DESCRIPTION
Changes `writeSyncFile` with `writeFileSync`.