### PR TITLE
Fixed messageFormat dependency omission and a timezone-dependent test

### DIFF
--- a/lib/compile.js
+++ b/lib/compile.js
@@ -54,6 +54,7 @@ DEPENDENCIES_VARS = {
 		dateParserFn: true
 	},
 	messageFormatter: {
+		messageFormat: true,
 		messageFormatterFn: true
 	},
 	numberFormatter: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -784,9 +784,9 @@
       }
     },
     "cldrjs": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/cldrjs/-/cldrjs-0.5.1.tgz",
-      "integrity": "sha512-xyiP8uAm8K1IhmpDndZLraloW1yqu0L+HYdQ7O1aGPxx9Cr+BMnPANlNhSt++UKfxytL2hd2NPXgTjiy7k43Ew==",
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/cldrjs/-/cldrjs-0.5.5.tgz",
+      "integrity": "sha512-KDwzwbmLIPfCgd8JERVDpQKrUUM1U4KpFJJg2IROv89rF172lLufoJnqJ/Wea6fXL5bO6WjuLMzY8V52UWPvkA==",
       "dev": true
     },
     "cli": {
@@ -2372,12 +2372,12 @@
       }
     },
     "globalize": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/globalize/-/globalize-1.4.3.tgz",
-      "integrity": "sha512-94z8goQsUbldMBICgQff10PBmL0viyeb3msSUiwDbqaOo+Syq1m2KO5R729STNDdUcUU0676prDDaEPTdrmxrw==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/globalize/-/globalize-1.6.0.tgz",
+      "integrity": "sha512-MTuAU3Tnbtga8PvxbpSPdQNIs6K5UdATWIuarWJK2Z3e1DghXpxb/GmShSVagzHqCOYgZr7N/Hi7D1mrHG30jQ==",
       "dev": true,
       "requires": {
-        "cldrjs": "^0.5.0"
+        "cldrjs": "^0.5.4"
       }
     },
     "globals": {

--- a/test/functional/index.js
+++ b/test/functional/index.js
@@ -36,9 +36,15 @@ describe("The compiled `basic.js`", function() {
 	});
 
 	it("should include support for dateParser", function() {
-		var result = Globalize.dateParser({skeleton: "MMMd", timeZone: "America/New_York"})("Jan 1");
-		expect(result.getMonth()).to.equal(0);
-		expect(result.getDate()).to.equal(1);
+		// When it is Feb 23 in New York, it has already been Feb 23rd in GMT for 4 or 5 hours (depending on DST).
+		var inNewYorkTime = Globalize.dateParser({skeleton: "MMMd", timeZone: "America/New_York"})("Feb 23");
+		expect(inNewYorkTime.getUTCMonth()).to.equal(1);
+		expect(inNewYorkTime.getUTCDate()).to.equal(23);
+
+		// When it is Feb 23 in Oslo, it is not yet (by 1 hour) Feb 23rd in GMT.
+		var inOsloTime = Globalize.dateParser({skeleton: "MMMd", timeZone: "Europe/Oslo"})("Feb 23");
+		expect(inOsloTime.getUTCMonth()).to.equal(1);
+		expect(inOsloTime.getUTCDate()).to.equal(22);
 	});
 
 	it("should include support for parseDate", function() {

--- a/test/unit/fixtures/basic.js
+++ b/test/unit/fixtures/basic.js
@@ -29,6 +29,9 @@ console.log(Globalize.formatDateToParts(new Date(), {date: "long"}));
 var dateParser = Globalize.dateParser({skeleton: "MMMd", timeZone: "America/New_York"});
 console.log(dateParser("Jan 1"));
 
+dateParser = Globalize.dateParser({skeleton: "MMMd", timeZone: "Europe/Oslo"});
+console.log(dateParser("Jan 1"));
+
 // Use parseDate.
 console.log(Globalize.parseDate("1/2/1982"));
 


### PR DESCRIPTION
A DEPENDENCY_VARS dependency on `messageFormat` (by `messageFormatter`)  was accidentally deleted by https://github.com/globalizejs/globalize-compiler/pull/42. 

This PR restores that dependency, fixing https://github.com/globalizejs/globalize-compiler/issues/45.

We also identified (by virtue of being in PST) a timezone-dependent test, and have replaced it with an enhanced, timezone-independent test.

This PR was co-authored by @dharrie-hbo, but I don't seem to have permissions to add him. Could you please add him as co-author to this PR? Thanks!
